### PR TITLE
skip cleanup before npm deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ deploy:
   on:
     branch: master
     condition: $VERSION != $VER_DEPL
+  skip_cleanup: true
 notifications:
   slack:
     secure: gnKw/BvuTAKFIxVwn0CtaEli4Md7NZPb3Pz0OqadzPv69jXKe1UehR1aunif6uae71Or1LqV19ez1/6JnjLjLpjQ0Zr4qmN+hY4mDNkuIToValGmsaRBqaB10JVzbgDvH2gZfucMdazpoPhNxbixRZw89hnm2psyJbm9nx2Ys9BGzu/F0D1+wIkVhsuLWf5NHUURSgSUvUvKuJtgX7HetbADbs5tqABGoKkBVhoWEyVKEn3TCKTczIaw2xFMXbt3KTFohlUM2wg2KqmbEHAZ1cbb6dWJM6chaLeBuBIv+HAjgWEz6kL8ongo8kvz2ip/x/xcrLfJXFC2tJjTHCVpYLmKhTWoVlAVBDKrEQEfDZTpbxUUO+BEAE7Fr+6RkNYdgdOqtVXLHaFRcbRUSUV+x7TJCKboZ06suKUFjzjZsHxST2xHDk8NNLcGr8e54SJl+44bgPRXTSStlNqf5ZQxS/bThgnb79nWgRc5eBxkbRThWRgnJwzSpAoDY2qWRcb+wtN/ct8mEvKNMCS+V4LZNdZbbk+77enZEeYBFgb7JcBrXZ3/xdUbNsKDRN66n2q8/O+cLKEjLQORd+43w1WoAMa/EL8kqOKQvu22Is6E0gyH0HiTHlY2rfm4hfyofD4yH8s1KbNk+tqQPQuHVaNTBl+8fOStHKUO0zJeHD4Kj9M=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-annotation",
-  "version": "2.0.56",
+  "version": "2.0.57",
   "description": "OpenTok annotation accelerator pack",
   "main": "dist/opentok-annotation.js",
   "directories": {


### PR DESCRIPTION
The last npm version was deployed without the dist folder.
This will cause anything using it to fail.
I believe this is due to the lack of `skip_cleanup: true` in the travis.yml.
See from  travis docs:

>After your tests ran and before the deploy, Travis CI will clean up any additional files and 
 changes you made.
 Maybe that is not what you want, as you might generate some artifacts (think asset compilation) 
 that are supposed to be deployed, too. There is now an option to skip the clean up:
```
 deploy:
   skip_cleanup: true
 ```

This field is present on the acc-core travis.yml which deploys succesfully: https://github.com/opentok/accelerator-core-js/blob/master/.travis.yml#L24